### PR TITLE
Strain smoothing one pass method

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -15,26 +15,26 @@ runtimes:
     - python@3.10.8
 lint:
   enabled:
-    - actionlint@1.7.1
+    - actionlint@1.7.2
     - hadolint@2.12.0
     - taplo@0.9.3
-    - bandit@1.7.9
+    - bandit@1.7.10
     - black@24.8.0
     - isort@5.13.2
-    - ruff@0.6.5
+    - ruff@0.6.7
     - shellcheck@0.10.0
     - shfmt@3.6.0
     - pragma-once
     #    - include-what-you-use@0.20
     - clang-tidy@16.0.3
     - clang-format@16.0.3
-    - trivy@0.55.1
+    - trivy@0.55.2
     - yamllint@1.35.1
-    - checkov@3.2.254
+    - checkov@3.2.255
     - git-diff-check
-    - markdownlint@0.41.0
+    - markdownlint@0.42.0
     - prettier@3.3.3
-    - trufflehog@3.82.2
+    - trufflehog@3.82.4
   disabled:
     - include-what-you-use
   ignore:

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,37 +29,46 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 #################### System Packages from apt ####################
 # Install necessary packages
+# trunk-ignore(hadolint/DL3008)
+# trunk-ignore(checkov/CKV2_DOCKER_1)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential=12.9ubuntu3 \
-    ca-certificates=20230311ubuntu0.22.04.1 \
-    coreutils=8.32-4.1ubuntu1.2 \
-    curl=7.81.0-1ubuntu1.16 \
-    environment-modules=5.0.1-1 \
-    file=1:5.41-3ubuntu0.1 \
-    gfortran=4:11.2.0-1ubuntu1 \
-    git=1:2.34.1-1ubuntu1.11 \
-    git-lfs=3.0.2-1ubuntu0.2 \
-    gpg=2.2.27-3ubuntu2.1 \
-    lcov=1.15-1 \
-    libcurl4-openssl-dev=7.81.0-1ubuntu1.16 \
-    libgl1=1.4.0-1 \
-    libglu1-mesa=9.0.2-1 \
-    libssl-dev=3.0.2-0ubuntu1.17 \
-    lsb-release=11.1.0ubuntu4 \
-    openssl=3.0.2-0ubuntu1.17 \
-    python3=3.10.6-1~22.04 \
-    python3-distutils=3.10.8-1~22.04 \
-    python3-venv=3.10.6-1~22.04 \
-    python3-pip=22.0.2+dfsg-1ubuntu0.4 \
-    unzip=6.0-26ubuntu3.2 \
-    vim=2:8.2.3995-1ubuntu2.17 \
-    xorg=1:7.7+23ubuntu2 \
-    zip=3.0-12build2 \
+    build-essential \
+    ca-certificates \
+    coreutils \
+    curl \
+    environment-modules \
+    file \
+    gfortran \
+    git \
+    git-lfs \
+    gpg \
+    lcov \
+    libcurl4-openssl-dev \
+    libgl1 \
+    libglu1-mesa \
+    libssl-dev \
+    lsb-release \
+    openssl \
+    python3 \
+    python3-distutils \
+    python3-venv \
+    python3-pip \
+    sudo \
+    unzip \
+    vim \
+    xorg \
+    zip \
     && rm -rf /var/lib/apt/lists/*
 
 #################### User Setup ####################
 # Create a non-root user
 RUN useradd -m aperi-mech_docker
+
+# Switch back to root user
+USER root
+
+# Configure passwordless sudo for the user
+RUN echo "aperi-mech_docker ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # Change to the new user
 USER aperi-mech_docker

--- a/Dockerfile_Nvidia_T4_GPU
+++ b/Dockerfile_Nvidia_T4_GPU
@@ -1,5 +1,4 @@
 # Dockerfile for building a GPU-enabled environment for the aperi-mech project
-# Base Image: Ubuntu 22.04
 # CUDA Architecture: 75 (Tesla T4)
 # This Dockerfile sets up a python and spack environment with necessary packages
 # After building the image, the user can run the container and start working on the aperi-mech project.
@@ -31,6 +30,16 @@
 #        docker build -t aperi-mech-gpu:latest -f Dockerfile_Nvidia_T4_GPU . 2>&1 | tee build.log
 #    4. Run the docker container using the following command (uses the docker-compose.yml file in the aperi-mech project):
 #        docker-compose -f docker-compose_nvidia_t4_gpu.yml run --service-ports aperi-mech-gpu-development /bin/bash
+#        Note: It is important that the drivers are the same in the image and the host system. If the there are problems with the drivers, the container will not be able to access the GPU.
+#        It is quicker to reinstall the drivers on the host system than to rebuild the image. Try the following commands:
+#            sudo apt-get update
+#            sudo apt-get upgrade
+#            sudo reboot
+#            sudo apt-get install linux-headers-$(uname -r)
+#            sudo apt-get purge nvidia*
+#            sudo apt-get install nvidia-driver-XXX # (XXX is the version number, make sure the full version number is the same as the one in the image, checked via nvidia-smi)
+#            sudo reboot
+#            # Reinstall the Nvidia Container Toolkit per the instructions above
 #    5. Start working on the aperi-mech project
 #       - Configure the project
 #          ./do_configure --gpu
@@ -44,8 +53,8 @@
 #       - Run the project performance tests:
 #          TODO(jake) implement: make run_all_performance_tests
 
-# Base image
-FROM ubuntu:22.04
+# Base image with CUDA support
+FROM nvidia/cuda:12.6.1-cudnn-runtime-ubuntu22.04
 
 # Avoid prompts from apt
 ENV DEBIAN_FRONTEND=noninteractive
@@ -56,36 +65,47 @@ ENV CUDA_ARCH=75
 #################### System Packages from apt ####################
 # Install necessary packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential=12.9ubuntu3 \
-    ca-certificates=20230311ubuntu0.22.04.1 \
-    coreutils=8.32-4.1ubuntu1.2 \
-    curl=7.81.0-1ubuntu1.16 \
-    environment-modules=5.0.1-1 \
-    file=1:5.41-3ubuntu0.1 \
-    gfortran=4:11.2.0-1ubuntu1 \
-    git=1:2.34.1-1ubuntu1.11 \
-    git-lfs=3.0.2-1ubuntu0.2 \
-    gpg=2.2.27-3ubuntu2.1 \
-    lcov=1.15-1 \
-    libcurl4-openssl-dev=7.81.0-1ubuntu1.16 \
-    libgl1=1.4.0-1 \
-    libglu1-mesa=9.0.2-1 \
-    libssl-dev=3.0.2-0ubuntu1.17 \
-    lsb-release=11.1.0ubuntu4 \
-    openssl=3.0.2-0ubuntu1.17 \
-    python3=3.10.6-1~22.04 \
-    python3-distutils=3.10.8-1~22.04 \
-    python3-venv=3.10.6-1~22.04 \
-    python3-pip=22.0.2+dfsg-1ubuntu0.4 \
-    unzip=6.0-26ubuntu3.2 \
-    vim=2:8.2.3995-1ubuntu2.17 \
-    xorg=1:7.7+23ubuntu2 \
-    zip=3.0-12build2 \
+    build-essential \
+    ca-certificates \
+    coreutils \
+    curl \
+    environment-modules \
+    file \
+    gfortran \
+    git \
+    git-lfs \
+    gpg \
+    lcov \
+    libcurl4-openssl-dev \
+    libgl1 \
+    libglu1-mesa \
+    libssl-dev \
+    lsb-release \
+    openssl \
+    python3 \
+    python3-distutils \
+    python3-venv \
+    python3-pip \
+    sudo \
+    unzip \
+    vim \
+    xorg \
+    zip \
     && rm -rf /var/lib/apt/lists/*
+
+# Install NVIDIA utilities (nvidia-smi)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    nvidia-utils-535
 
 #################### User Setup ####################
 # Create a non-root user
 RUN useradd -m aperi-mech_docker
+
+# Switch back to root user
+USER root
+
+# Configure passwordless sudo for the user
+RUN echo "aperi-mech_docker ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # Change to the new user
 USER aperi-mech_docker
@@ -135,7 +155,6 @@ RUN spack compiler find && \
 RUN spack env create aperi-mech
 
 # Add packages to the Spack environment, aperi-mech
-# Compadre should be version 1.5.9 (need to update the spack package to get that version as of July 2024)
 RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
     spack -e aperi-mech add compadre@master ~tests && \
     spack -e aperi-mech add kokkos-kernels@4.3.01 +cuda ~shared cuda_arch=${CUDA_ARCH} && \

--- a/docker-compose_nvidia_t4_gpu.yml
+++ b/docker-compose_nvidia_t4_gpu.yml
@@ -22,7 +22,9 @@ services:
       resources:
         reservations:
           devices:
-            - capabilities: [gpu]
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility

--- a/include/Element.h
+++ b/include/Element.h
@@ -40,7 +40,8 @@ inline std::shared_ptr<ElementBase> CreateElement(const aperi::ElementTopology& 
         } else if (ApproximationSpaceType::ReproducingKernel == approximation_space_parameters->GetApproximationSpaceType()) {
             if (integration_scheme_parameters->GetIntegrationSchemeType() == IntegrationSchemeType::StrainSmoothing) {
                 double kernel_radius_scale_factor = approximation_space_parameters->GetKernelRadiusScaleFactor();
-                return std::make_shared<ElementReproducingKernelTet4>(field_query_data_gather, part_names, mesh_data, material, kernel_radius_scale_factor);
+                bool use_one_pass_method = integration_scheme_parameters->UsesOnePassMethod();
+                return std::make_shared<ElementReproducingKernelTet4>(field_query_data_gather, part_names, mesh_data, material, kernel_radius_scale_factor, use_one_pass_method);
             } else {
                 throw std::runtime_error("Gauss Quadrature is not supported for Reproducing Kernel");
             }
@@ -53,7 +54,8 @@ inline std::shared_ptr<ElementBase> CreateElement(const aperi::ElementTopology& 
         } else if (ApproximationSpaceType::ReproducingKernel == approximation_space_parameters->GetApproximationSpaceType()) {
             if (integration_scheme_parameters->GetIntegrationSchemeType() == IntegrationSchemeType::StrainSmoothing) {
                 double kernel_radius_scale_factor = approximation_space_parameters->GetKernelRadiusScaleFactor();
-                return std::make_shared<ElementReproducingKernelHex8>(field_query_data_gather, part_names, mesh_data, material, kernel_radius_scale_factor);
+                bool use_one_pass_method = integration_scheme_parameters->UsesOnePassMethod();
+                return std::make_shared<ElementReproducingKernelHex8>(field_query_data_gather, part_names, mesh_data, material, kernel_radius_scale_factor, use_one_pass_method);
             } else {
                 throw std::runtime_error("Gauss Quadrature is not supported for Reproducing Kernel");
             }

--- a/include/ElementProcessor.h
+++ b/include/ElementProcessor.h
@@ -559,11 +559,13 @@ class StrainSmoothingProcessor {
         return passed;
     }
 
-    std::shared_ptr<aperi::SmoothedCellData> BuildSmoothedCellData(size_t estimated_num_nodes_per_cell) {
+    std::shared_ptr<aperi::SmoothedCellData> BuildSmoothedCellData(size_t estimated_num_nodes_per_cell, bool one_pass_method = true) {
         /* This needs a few things to be completed first:
            - The mesh labeler needs to be run to get the cell ids and create the _cells parts.
            - The node function derivatives need to be computed.
         */
+
+        aperi::CoutP0() << "Building smoothed cell data." << std::endl;
 
         // Create the cells selector
         std::vector<std::string> cells_sets;
@@ -596,6 +598,18 @@ class StrainSmoothingProcessor {
         m_ngp_element_volume_field->sync_to_host();
         for (size_t i = 0; i < 3; ++i) {
             m_ngp_element_function_derivatives_fields[i]->sync_to_host();
+        }
+
+        // Needed for the one pass method
+        stk::mesh::Field<uint64_t> *neighbors_field = nullptr;
+        stk::mesh::Field<uint64_t> *num_neighbors_field = nullptr;
+        stk::mesh::Field<double> *function_values_field = nullptr;
+
+        if (one_pass_method) {
+            // Get the neighbors, num_neighbors, and function_values fields
+            neighbors_field = StkGetField(FieldQueryData<uint64_t>{"neighbors", FieldQueryState::None, FieldDataTopologyRank::NODE}, &m_bulk_data->mesh_meta_data());
+            num_neighbors_field = StkGetField(FieldQueryData<uint64_t>{"num_neighbors", FieldQueryState::None, FieldDataTopologyRank::NODE}, &m_bulk_data->mesh_meta_data());
+            function_values_field = StkGetField(FieldQueryData<double>{"function_values", FieldQueryState::None, FieldDataTopologyRank::NODE}, &m_bulk_data->mesh_meta_data());
         }
 
         // Get the ngp fields
@@ -654,6 +668,8 @@ class StrainSmoothingProcessor {
         // Get host views of the node local offsets
         auto node_local_offsets = smoothed_cell_data->GetNodeLocalOffsetsHost();
 
+        double average_num_neighbors = 0;
+        double average_num_nodes = 0;
         // Loop over all the cells
         for (size_t i = 0, e = smoothed_cell_data->NumCells(); i < e; ++i) {
             // Get the cell element local offsets
@@ -661,6 +677,7 @@ class StrainSmoothingProcessor {
 
             // Create a map of node entities to their indices
             std::unordered_map<uint64_t, size_t> node_entities;
+            std::unordered_map<uint64_t, size_t> node_neighbor_entities;
 
             // Loop over all the cell element local offsets
             for (size_t j = 0, je = cell_element_local_offsets.size(); j < je; ++j) {
@@ -672,12 +689,29 @@ class StrainSmoothingProcessor {
                     uint64_t node_local_offset = element_nodes[k].local_offset();
                     if (node_entities.find(node_local_offset) == node_entities.end()) {
                         node_entities[node_local_offset] = node_entities.size();
+                        if (one_pass_method) {
+                            // Get the node neighbors
+                            uint64_t num_neighbors = stk::mesh::field_data(*num_neighbors_field, element_nodes[k])[0];
+                            uint64_t *neighbors = stk::mesh::field_data(*neighbors_field, element_nodes[k]);
+                            for (size_t l = 0; l < num_neighbors; ++l) {
+                                uint64_t neighbor = neighbors[l];
+                                if (node_neighbor_entities.find(neighbor) == node_neighbor_entities.end()) {
+                                    node_neighbor_entities[neighbor] = node_neighbor_entities.size();
+                                }
+                            }
+                        }
                     }
                 }
             }
 
             // Set the length to the size of the map
-            node_lengths(i) = node_entities.size();
+            if (one_pass_method) {
+                node_lengths(i) = node_neighbor_entities.size();
+                average_num_neighbors += static_cast<double>(node_neighbor_entities.size());
+            } else {
+                node_lengths(i) = node_entities.size();
+            }
+            average_num_nodes += static_cast<double>(node_entities.size());
 
             // Set the start to the start + length of the previous cell, if not the first cell
             if (i > 0) {
@@ -705,7 +739,8 @@ class StrainSmoothingProcessor {
             // Loop over the node entities, create a map of local offsets to node indices
             std::unordered_map<uint64_t, size_t> node_local_offsets_to_index;
             size_t node_index = node_starts(i);
-            for (const auto &node_pair : node_entities) {
+            std::unordered_map<uint64_t, size_t> &node_entities_to_use = one_pass_method ? node_neighbor_entities : node_entities;
+            for (const auto &node_pair : node_entities_to_use) {
                 uint64_t node_local_offset = node_pair.first;
                 node_local_offsets(node_index) = node_local_offset;
                 node_local_offsets_to_index[node_local_offset] = node_index;
@@ -728,14 +763,40 @@ class StrainSmoothingProcessor {
                 }
                 // Loop over all the nodes in the element
                 for (size_t k = 0, ke = m_bulk_data->num_nodes(element); k < ke; ++k) {
-                    uint64_t node_local_offset = element_nodes[k].local_offset();
-                    size_t node_component_index = node_local_offsets_to_index[node_local_offset] * 3;
-                    // Atomic add to the derivatives and set the node local offsets for the cell
-                    for (size_t l = 0; l < 3; ++l) {
-                        Kokkos::atomic_add(&node_function_derivatives(node_component_index + l), element_function_derivatives_data[l][k] * cell_volume_fraction);
+                    if (one_pass_method) {
+                        uint64_t num_neighbors = stk::mesh::field_data(*num_neighbors_field, element_nodes[k])[0];
+                        // Loop over the nodes neighbors
+                        for (size_t l = 0; l < num_neighbors; ++l) {
+                            uint64_t neighbor = stk::mesh::field_data(*neighbors_field, element_nodes[k])[l];
+                            double function_value = stk::mesh::field_data(*function_values_field, element_nodes[k])[l];
+                            auto neighbor_iter = node_local_offsets_to_index.find(neighbor);
+                            assert(neighbor_iter != node_local_offsets_to_index.end());
+                            if (neighbor_iter != node_local_offsets_to_index.end()) {
+                                size_t neighbor_index = neighbor_iter->second;
+                                // Atomic add to the derivatives and set the node local offsets for the cell
+                                for (size_t m = 0; m < 3; ++m) {
+                                    Kokkos::atomic_add(&node_function_derivatives(neighbor_index * 3 + m), element_function_derivatives_data[m][k] * cell_volume_fraction * function_value);
+                                }
+                            } else {
+                                aperi::CoutP0() << "Node " << neighbor << " not found in node local offsets." << std::endl;
+                            }
+                        }
+                    } else {
+                        uint64_t node_local_offset = element_nodes[k].local_offset();
+                        size_t node_component_index = node_local_offsets_to_index[node_local_offset] * 3;
+                        // Atomic add to the derivatives and set the node local offsets for the cell
+                        for (size_t l = 0; l < 3; ++l) {
+                            Kokkos::atomic_add(&node_function_derivatives(node_component_index + l), element_function_derivatives_data[l][k] * cell_volume_fraction);
+                        }
                     }
                 }
             }
+        }
+        average_num_nodes /= static_cast<double>(num_cells);
+        aperi::CoutP0() << "Average number of points defining a cell: " << average_num_nodes << std::endl;
+        if (one_pass_method) {
+            average_num_neighbors /= static_cast<double>(num_cells);
+            aperi::CoutP0() << "Average number of neighbors for a cell: " << average_num_neighbors << std::endl;
         }
         bool set_start_from_lengths = false;  // The start array is already set above. This can be done as we are on host and looping through sequentially.
         smoothed_cell_data->CompleteAddingCellNodeIndicesOnHost(set_start_from_lengths);

--- a/include/ElementReproducingKernel.h
+++ b/include/ElementReproducingKernel.h
@@ -34,7 +34,7 @@ class ElementReproducingKernel : public ElementBase {
     /**
      * @brief Constructs a ElementReproducingKernel object.
      */
-    ElementReproducingKernel(const std::vector<FieldQueryData<double>> &field_query_data_gather, const std::vector<std::string> &part_names, std::shared_ptr<MeshData> mesh_data, std::shared_ptr<Material> material = nullptr, double kernel_radius_scale_factor = 1.0) : ElementBase(NumCellNodes, material), m_field_query_data_gather(field_query_data_gather), m_part_names(part_names), m_mesh_data(mesh_data), m_kernel_radius_scale_factor(kernel_radius_scale_factor) {
+    ElementReproducingKernel(const std::vector<FieldQueryData<double>> &field_query_data_gather, const std::vector<std::string> &part_names, std::shared_ptr<MeshData> mesh_data, std::shared_ptr<Material> material = nullptr, double kernel_radius_scale_factor = 1.0, bool use_one_pass_method = true) : ElementBase(NumCellNodes, material), m_field_query_data_gather(field_query_data_gather), m_part_names(part_names), m_mesh_data(mesh_data), m_kernel_radius_scale_factor(kernel_radius_scale_factor), m_use_one_pass_method(use_one_pass_method) {
         // Find and store the element neighbors
         CreateElementProcessor();
         FindNeighbors();
@@ -119,7 +119,7 @@ class ElementReproducingKernel : public ElementBase {
     double m_kernel_radius_scale_factor;
     std::shared_ptr<aperi::ElementGatherScatterProcessor<2, true>> m_element_processor;
     std::shared_ptr<aperi::SmoothedCellData> m_smoothed_cell_data;
-    bool m_use_one_pass_method = true;
+    bool m_use_one_pass_method;
 };
 
 /**
@@ -134,7 +134,7 @@ class ElementReproducingKernelTet4 : public ElementReproducingKernel<aperi::TET4
     /**
      * @brief Constructs a ElementReproducingKernelTet4 object.
      */
-    ElementReproducingKernelTet4(const std::vector<FieldQueryData<double>> &field_query_data_gather, const std::vector<std::string> &part_names, std::shared_ptr<MeshData> mesh_data, std::shared_ptr<Material> material = nullptr, double kernel_radius_scale_factor = 1.0) : ElementReproducingKernel<aperi::TET4_NUM_NODES>(field_query_data_gather, part_names, mesh_data, material, kernel_radius_scale_factor) {
+    ElementReproducingKernelTet4(const std::vector<FieldQueryData<double>> &field_query_data_gather, const std::vector<std::string> &part_names, std::shared_ptr<MeshData> mesh_data, std::shared_ptr<Material> material = nullptr, double kernel_radius_scale_factor = 1.0, bool use_one_pass_method = true) : ElementReproducingKernel<aperi::TET4_NUM_NODES>(field_query_data_gather, part_names, mesh_data, material, kernel_radius_scale_factor, use_one_pass_method) {
         ComputeSmoothedQuadrature();
     }
 
@@ -177,7 +177,7 @@ class ElementReproducingKernelHex8 : public ElementReproducingKernel<aperi::HEX8
     /**
      * @brief Constructs a ElementReproducingKernelHex8 object.
      */
-    ElementReproducingKernelHex8(const std::vector<FieldQueryData<double>> &field_query_data_gather, const std::vector<std::string> &part_names, std::shared_ptr<MeshData> mesh_data, std::shared_ptr<Material> material = nullptr, double kernel_radius_scale_factor = 1.0) : ElementReproducingKernel<aperi::HEX8_NUM_NODES>(field_query_data_gather, part_names, mesh_data, material, kernel_radius_scale_factor) {
+    ElementReproducingKernelHex8(const std::vector<FieldQueryData<double>> &field_query_data_gather, const std::vector<std::string> &part_names, std::shared_ptr<MeshData> mesh_data, std::shared_ptr<Material> material = nullptr, double kernel_radius_scale_factor = 1.0, bool use_one_pass_method = true) : ElementReproducingKernel<aperi::HEX8_NUM_NODES>(field_query_data_gather, part_names, mesh_data, material, kernel_radius_scale_factor, use_one_pass_method) {
         ComputeSmoothedQuadrature();
     }
 

--- a/include/InternalForceContribution.h
+++ b/include/InternalForceContribution.h
@@ -73,6 +73,21 @@ class InternalForceContribution : public ForceContribution {
         return m_internal_force_contribution_parameters.approximation_space_parameters->UsesGeneralizedFields();
     }
 
+    /**
+     * @brief Gets whether the element uses one pass method.
+     *
+     * @return True if the element uses one pass method, false otherwise.
+     */
+    bool UsesOnePassMethod() const {
+        return m_internal_force_contribution_parameters.integration_scheme_parameters->UsesOnePassMethod();
+    }
+
+    /**
+     * @brief Preprocesses the internal force contribution.
+     *
+     * This function overrides the Preprocess function from the base class.
+     * It preprocesses the internal force contribution.
+     */
     void Preprocess() override;
 
    protected:

--- a/include/InternalForceContributionParameters.h
+++ b/include/InternalForceContributionParameters.h
@@ -113,9 +113,14 @@ class IntegrationSchemeParameters {
         return integration_scheme;
     }
 
+    bool UsesOnePassMethod() const {
+        return uses_one_pass_method;
+    }
+
    protected:
     std::string integration_scheme = "gauss_quadrature";
     IntegrationSchemeType integration_scheme_type = IntegrationSchemeType::GaussQuadrature;
+    bool uses_one_pass_method = true;
 };
 
 class IntegrationSchemeGaussQuadratureParameters : public IntegrationSchemeParameters {
@@ -146,10 +151,12 @@ class IntegrationSchemeStrainSmoothingParameters : public IntegrationSchemeParam
     IntegrationSchemeStrainSmoothingParameters() {
         integration_scheme = "strain_smoothing";
         integration_scheme_type = IntegrationSchemeType::StrainSmoothing;
+        uses_one_pass_method = true;
     }
     IntegrationSchemeStrainSmoothingParameters(const YAML::Node& strain_smoothing_node) {
         integration_scheme = "strain_smoothing";
         integration_scheme_type = IntegrationSchemeType::StrainSmoothing;
+        uses_one_pass_method = true;
     }
     virtual ~IntegrationSchemeStrainSmoothingParameters() = default;
 };

--- a/include/IoInputSchema.h
+++ b/include/IoInputSchema.h
@@ -323,6 +323,14 @@ YAML::Node GetInputSchema() {
     aperi::InputSchema subdomains_schema("subdomains", "int", "the number of smoothing cell subdomains");
     YAML::Node subdomains_node = subdomains_schema.GetInputSchema();
 
+    // Force one pass method node
+    aperi::InputSchema force_one_pass_method_schema("force_one_pass_method", "bool", "force the one pass method");
+    YAML::Node force_one_pass_method_node = force_one_pass_method_schema.GetInputSchema();
+
+    // Force two pass method node
+    aperi::InputSchema force_two_pass_method_schema("force_two_pass_method", "bool", "force the two pass method");
+    YAML::Node force_two_pass_method_node = force_two_pass_method_schema.GetInputSchema();
+
     // Nodal smoothing cell node
     aperi::InputSchema nodal_smoothing_cell_schema("nodal_smoothing_cell", "map", "a nodal smoothing cell");
     nodal_smoothing_cell_schema.AddAllOf(subdomains_node);
@@ -337,6 +345,8 @@ YAML::Node GetInputSchema() {
     aperi::InputSchema strain_smoothing_schema("strain_smoothing", "map", "strain smoothing");
     strain_smoothing_schema.AddOneOf(nodal_smoothing_cell_node);
     strain_smoothing_schema.AddOneOf(element_smoothing_cell_node);
+    strain_smoothing_schema.AddOptional(force_one_pass_method_node);
+    strain_smoothing_schema.AddOptional(force_two_pass_method_node);
     YAML::Node strain_smoothing_node = strain_smoothing_schema.GetInputSchema();
 
     // Integration scheme node

--- a/src/InternalForceContribution.cpp
+++ b/src/InternalForceContribution.cpp
@@ -17,7 +17,7 @@ void InternalForceContribution::Preprocess() {
     std::vector<FieldQueryData<double>> field_query_data_gather;
     if (m_internal_force_contribution_parameters.integration_scheme_parameters->GetIntegrationSchemeType() == IntegrationSchemeType::StrainSmoothing) {  // TODO(jake): this doesn't have to have coordinates
         field_query_data_gather.resize(2);
-        if (UsesGeneralizedFields()) {
+        if (UsesGeneralizedFields() && (UsesOnePassMethod() == false)) {
             // If using generalized fields, use the gathered fields
             field_query_data_gather[0] = FieldQueryData<double>{"displacement", FieldQueryState::None};
             field_query_data_gather[1] = FieldQueryData<double>{"velocity", FieldQueryState::None};
@@ -35,7 +35,7 @@ void InternalForceContribution::Preprocess() {
     // Get the number of nodes per element
     aperi::ElementTopology element_topology = m_internal_force_contribution_parameters.mesh_data->GetElementTopology(m_internal_force_contribution_parameters.part_name);
 
-    // Create the element.
+    // Create the element. TODO(jake): Can pass one_pass flag into CreateElement
     m_element = CreateElement(element_topology, m_internal_force_contribution_parameters.approximation_space_parameters, m_internal_force_contribution_parameters.integration_scheme_parameters, field_query_data_gather, part_names, m_internal_force_contribution_parameters.mesh_data, m_internal_force_contribution_parameters.material);
 }
 

--- a/src/InternalForceContribution.cpp
+++ b/src/InternalForceContribution.cpp
@@ -17,7 +17,7 @@ void InternalForceContribution::Preprocess() {
     std::vector<FieldQueryData<double>> field_query_data_gather;
     if (m_internal_force_contribution_parameters.integration_scheme_parameters->GetIntegrationSchemeType() == IntegrationSchemeType::StrainSmoothing) {  // TODO(jake): this doesn't have to have coordinates
         field_query_data_gather.resize(2);
-        if (UsesGeneralizedFields() && (UsesOnePassMethod() == false)) {
+        if (UsesGeneralizedFields() && (!UsesOnePassMethod())) {
             // If using generalized fields, use the gathered fields
             field_query_data_gather[0] = FieldQueryData<double>{"displacement", FieldQueryState::None};
             field_query_data_gather[1] = FieldQueryData<double>{"velocity", FieldQueryState::None};
@@ -35,7 +35,7 @@ void InternalForceContribution::Preprocess() {
     // Get the number of nodes per element
     aperi::ElementTopology element_topology = m_internal_force_contribution_parameters.mesh_data->GetElementTopology(m_internal_force_contribution_parameters.part_name);
 
-    // Create the element. TODO(jake): Can pass one_pass flag into CreateElement
+    // Create the element.
     m_element = CreateElement(element_topology, m_internal_force_contribution_parameters.approximation_space_parameters, m_internal_force_contribution_parameters.integration_scheme_parameters, field_query_data_gather, part_names, m_internal_force_contribution_parameters.mesh_data, m_internal_force_contribution_parameters.material);
 }
 

--- a/src/IoInputFile.cpp
+++ b/src/IoInputFile.cpp
@@ -72,6 +72,11 @@ std::pair<std::map<std::string, YAML::Node>, int> GetInputNodes(const YAML::Node
             if (!scalar_pair.second) {
                 ++found_count;
             }
+        } else if (type == "bool") {
+            std::pair<bool, int> scalar_pair = GetScalarValue<bool>(input_node, name, verbose, optional);
+            if (!scalar_pair.second) {
+                ++found_count;
+            }
         } else if (type == "float_vector") {
             std::pair<std::vector<double>, int> scalar_pair = GetValueSequence<double>(input_node, name, verbose, optional);
             if (!scalar_pair.second) {
@@ -88,7 +93,7 @@ std::pair<std::map<std::string, YAML::Node>, int> GetInputNodes(const YAML::Node
                 ++found_count;
             }
         } else {
-            throw std::runtime_error("Schema Error: 'one_or_more_of' subitems must be of type 'node', 'float', 'float_vector', 'string', or 'double_list'. Line: " + std::to_string(__LINE__));
+            throw std::runtime_error("Schema Error: 'one_or_more_of' subitems must be of type 'int', 'bool', 'node', 'float', 'float_vector', 'string', or 'double_list'. Line: " + std::to_string(__LINE__));
         }
     }
     return std::make_pair(found_names_and_nodes, found_count);

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -71,7 +71,7 @@ void ExplicitSolver::ComputeForce() {
     m_node_processor_force->MarkFieldModifiedOnDevice(0);
 
     // Compute kinematic field values from the generalized fields
-    if (m_uses_generalized_fields) {
+    if (m_uses_generalized_fields && (m_uses_one_pass_method == false)) {
         m_kinematics_from_generalized_field_processor->compute_value_from_generalized_field();
         m_kinematics_from_generalized_field_processor->MarkAllDestinationFieldsModifiedOnDevice();
         m_node_processor_force_local->FillField(0.0, 0);
@@ -84,7 +84,7 @@ void ExplicitSolver::ComputeForce() {
     }
 
     // Scatter the local forces. May have to be done after the external forces are computed if things change in the future.
-    if (m_uses_generalized_fields) {
+    if (m_uses_generalized_fields && (m_uses_one_pass_method == false)) {
         if (m_num_processors > 1) {
             m_node_processor_force_local->SyncFieldDeviceToHost(0);
             m_node_processor_force_local->ParallelSumFieldData(0);

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -71,7 +71,7 @@ void ExplicitSolver::ComputeForce() {
     m_node_processor_force->MarkFieldModifiedOnDevice(0);
 
     // Compute kinematic field values from the generalized fields
-    if (m_uses_generalized_fields && (m_uses_one_pass_method == false)) {
+    if (m_uses_generalized_fields && (!m_uses_one_pass_method)) {
         m_kinematics_from_generalized_field_processor->compute_value_from_generalized_field();
         m_kinematics_from_generalized_field_processor->MarkAllDestinationFieldsModifiedOnDevice();
         m_node_processor_force_local->FillField(0.0, 0);
@@ -84,7 +84,7 @@ void ExplicitSolver::ComputeForce() {
     }
 
     // Scatter the local forces. May have to be done after the external forces are computed if things change in the future.
-    if (m_uses_generalized_fields && (m_uses_one_pass_method == false)) {
+    if (m_uses_generalized_fields && (!m_uses_one_pass_method)) {
         if (m_num_processors > 1) {
             m_node_processor_force_local->SyncFieldDeviceToHost(0);
             m_node_processor_force_local->ParallelSumFieldData(0);

--- a/test/regression_tests/taylor_bar/rkpm_one_pass/compare.exodiff
+++ b/test/regression_tests/taylor_bar/rkpm_one_pass/compare.exodiff
@@ -1,0 +1,74 @@
+
+#  *****************************************************************
+#             EXODIFF	(Version: 3.33) Modified: 2024-03-13
+#             Authors:  Richard Drake, rrdrake@sandia.gov           
+#                       Greg Sjaardema, gdsjaar@sandia.gov          
+#             Run on    2024/08/14   14:22:16 MDT
+#  *****************************************************************
+
+#  FILE 1: /Users/jake/projects/aperi-mech/test/regression_tests/taylor_bar/rkpm/gold_results.exo
+#   Title: IOSS Default Output Title
+#          Dim = 3, Nodes = 285, Elements = 904, Faces = 0, Edges = 0
+#          Element Blocks = 1, Face Blocks = 0, Edge Blocks = 0, Nodesets = 1, Sidesets = 0, Assemblies = 0
+#    Vars: Global = 0, Nodal = 32, Element = 1, Face = 0, Edge = 0, Nodeset = 0, Sideset = 0, Times = 2
+
+
+# ==============================================================
+#  NOTE: All node and element ids are reported as global ids.
+
+# NOTES:  - The min/max values are reporting the min/max in absolute value.
+#         - Time values (t) are 1-offset time step numbers.
+#         - Element block numbers are the block ids.
+#         - Node(n) and element(e) numbers are 1-offset.
+
+COORDINATES absolute 1.e-6    # min separation not calculated
+
+TIME STEPS relative 1.e-6 floor 0.0     # min:               0 @ t1 max:          0.0001 @ t2
+
+# No GLOBAL VARIABLES
+
+NODAL VARIABLES relative 1.e-6 floor 0.0
+	displacement_x                # min:               0 @ t1,n1	max:    0.0036785521 @ t2,n36
+	displacement_y                # min:               0 @ t1,n1	max:    0.0040839211 @ t2,n22
+	displacement_z                # min:               0 @ t1,n1	max:     0.037196514 @ t2,n266
+	acceleration_x                # min:               0 @ t1,n1	max:        36385984 @ t2,n11
+	acceleration_y                # min:               0 @ t1,n1	max:        21862567 @ t2,n9
+	acceleration_z                # min:               0 @ t1,n1	max:        14371222 @ t2,n58
+	acceleration_coefficients_x   # min:               0 @ t1,n1	max:        38691047 @ t2,n11
+	acceleration_coefficients_y   # min:               0 @ t1,n1	max:        21917086 @ t2,n9
+	acceleration_coefficients_z   # min:               0 @ t1,n1	max:        23869622 @ t2,n58
+	displacement_coefficients_x   # min:               0 @ t1,n1	max:    0.0043819137 @ t2,n54
+	displacement_coefficients_y   # min:               0 @ t1,n1	max:    0.0044476955 @ t2,n22
+	displacement_coefficients_z   # min:               0 @ t1,n1	max:     0.037202721 @ t2,n266
+	force_coefficients_x          # min:               0 @ t1,n1	max:       240280.72 @ t2,n82
+	force_coefficients_y          # min:               0 @ t1,n1	max:        281087.6 @ t2,n84
+	force_coefficients_z          # min:               0 @ t1,n1	max:       301224.61 @ t2,n63
+	force_local_x                 # min:               0 @ t1,n1	max:       339807.63 @ t2,n82
+	force_local_y                 # min:               0 @ t1,n1	max:       421056.18 @ t2,n84
+	force_local_z                 # min:               0 @ t1,n1	max:       948619.27 @ t2,n80
+	kernel_radius                 # min:     0.020585933 @ t1,n6	max:     0.043996934 @ t1,n41
+	mass_x                        # min:    0.0016845281 @ t1,n6	max:     0.032028645 @ t1,n84
+	mass_y                        # min:    0.0016845281 @ t1,n6	max:     0.032028645 @ t1,n84
+	mass_z                        # min:    0.0016845281 @ t1,n6	max:     0.032028645 @ t1,n84
+	mass_from_elements_x          # min:     0.001125266 @ t1,n221	max:     0.041543172 @ t1,n84
+	mass_from_elements_y          # min:     0.001125266 @ t1,n221	max:     0.041543172 @ t1,n84
+	mass_from_elements_z          # min:     0.001125266 @ t1,n221	max:     0.041543172 @ t1,n84
+	num_neighbors                 # min:              10 @ t1,n9	max:              27 @ t1,n82
+	velocity_x                    # min:               0 @ t1,n1	max:       123.52409 @ t2,n10
+	velocity_y                    # min:               0 @ t1,n1	max:       198.53068 @ t2,n13
+	velocity_z                    # min:     0.013343094 @ t2,n77	max:             373 @ t1,n10
+	velocity_coefficients_x       # min:               0 @ t1,n1	max:       124.61469 @ t2,n10
+	velocity_coefficients_y       # min:               0 @ t1,n1	max:       210.82657 @ t2,n13
+	velocity_coefficients_z       # min:               0 @ t2,n1	max:             373 @ t1,n1
+
+# ELEMENT VARIABLES relative 1.e-6 floor 0.0
+# 	volume                        # min:   2.6981576e-07 @ t1,b1,e660	max:   3.2081389e-06 @ t1,b1,e453
+
+# No NODESET VARIABLES
+
+# No SIDESET VARIABLES
+
+# No EDGE BLOCK VARIABLES
+
+# No FACE BLOCK VARIABLES
+

--- a/test/regression_tests/taylor_bar/rkpm_one_pass/compare.exodiff
+++ b/test/regression_tests/taylor_bar/rkpm_one_pass/compare.exodiff
@@ -43,9 +43,6 @@ NODAL VARIABLES relative 1.e-6 floor 0.0
 	force_coefficients_x          # min:               0 @ t1,n1	max:       240280.72 @ t2,n82
 	force_coefficients_y          # min:               0 @ t1,n1	max:        281087.6 @ t2,n84
 	force_coefficients_z          # min:               0 @ t1,n1	max:       301224.61 @ t2,n63
-	force_local_x                 # min:               0 @ t1,n1	max:       339807.63 @ t2,n82
-	force_local_y                 # min:               0 @ t1,n1	max:       421056.18 @ t2,n84
-	force_local_z                 # min:               0 @ t1,n1	max:       948619.27 @ t2,n80
 	kernel_radius                 # min:     0.020585933 @ t1,n6	max:     0.043996934 @ t1,n41
 	mass_x                        # min:    0.0016845281 @ t1,n6	max:     0.032028645 @ t1,n84
 	mass_y                        # min:    0.0016845281 @ t1,n6	max:     0.032028645 @ t1,n84

--- a/test/regression_tests/taylor_bar/rkpm_one_pass/input.yaml
+++ b/test/regression_tests/taylor_bar/rkpm_one_pass/input.yaml
@@ -1,0 +1,51 @@
+procedures:
+  - explicit_dynamics_procedure:
+      geometry:
+        mesh: ../mesh/cylinder0p02.exo
+        parts:
+          - part:
+              set: block_1
+              formulation:
+                integration_scheme:
+                  strain_smoothing:
+                    force_one_pass_method: true
+                    element_smoothing_cell:
+                      subdomains: 1
+                approximation_space:
+                  reproducing_kernel:
+                    kernel_radius_scale_factor: 1.1
+              material:
+                elastic:
+                  density: 2700.0 # kg / m^3
+                  # youngs_modulus: 78.2e9 # Pa, 78.2 GPa
+                  youngs_modulus: 78.2e8 # just scaling down a bit since there is no plasticity
+                  poissons_ratio: 0.3
+      initial_conditions:
+        - velocity:
+            sets:
+              - block_1
+            components:
+              Z: -373.0 # m/s
+      time_stepper:
+        direct_time_stepper:
+          time_increment: 0.000001
+          time_end: 0.0001
+      output:
+        file: results.exo
+        time_start: 0
+        time_end: 1
+        time_increment: 0.0001
+      boundary_conditions:
+        - displacement:
+            sets:
+              - nodeset_1
+            components:
+              Z: 0.0
+            time_function:
+              ramp_function:
+                abscissa_values:
+                  - 0
+                  - 1
+                ordinate_values:
+                  - 0
+                  - 1

--- a/test/regression_tests/taylor_bar/rkpm_one_pass/test.yaml
+++ b/test/regression_tests/taylor_bar/rkpm_one_pass/test.yaml
@@ -1,0 +1,34 @@
+# Define common settings
+defaults: &defaults
+  num_processors: 1
+  input_file: input.yaml
+  build: Release
+  cleanup:
+    remove: [results.exo, "*.log"]
+  exodiff:
+    - compare_file: compare.exodiff
+      gold_file: ../rkpm/gold_results.exo
+      results_file: results.exo
+
+# List of tests using the defaults
+tests:
+  - <<: *defaults
+    hardware: cpu
+    peak_memory_check:
+      value: 46.0 # Gold peak memory usage in MB
+      percent_tolerance: 10
+  - <<: *defaults
+    hardware: gpu
+  - <<: *defaults
+    num_processors: 4 # Override the default num_processors for this test
+    hardware: cpu
+  - <<: *defaults
+    hardware: gpu
+    build: Debug
+  - <<: *defaults
+    hardware: cpu
+    build: Debug
+  - <<: *defaults
+    num_processors: 4
+    hardware: cpu
+    build: Debug

--- a/test/unit_tests/PatchTestFixture.h
+++ b/test/unit_tests/PatchTestFixture.h
@@ -20,7 +20,9 @@
 
 enum PatchTestIntegrationScheme { GAUSS_QUADRATURE,
                                   ELEMENT_STRAIN_SMOOTHING,
-                                  NODAL_STRAIN_SMOOTHING };
+                                  NODAL_STRAIN_SMOOTHING,
+                                  ELEMENT_STRAIN_SMOOTHING_FORCE_ONE_PASS,
+                                  NODAL_STRAIN_SMOOTHING_FORCE_TWO_PASS };
 
 // Fixture for patch tests
 class PatchTest : public SolverTest {
@@ -93,8 +95,16 @@ class PatchTest : public SolverTest {
             YAML::Node strain_smoothing_node;
             if (integration_scheme == PatchTestIntegrationScheme::ELEMENT_STRAIN_SMOOTHING) {
                 strain_smoothing_node["element_smoothing_cell"] = element_smoothing_cell_node;
-            } else {
+            } else if (integration_scheme == PatchTestIntegrationScheme::ELEMENT_STRAIN_SMOOTHING_FORCE_ONE_PASS) {
+                strain_smoothing_node["element_smoothing_cell"] = element_smoothing_cell_node;
+                strain_smoothing_node["force_one_pass_method"] = true;
+            } else if (integration_scheme == PatchTestIntegrationScheme::NODAL_STRAIN_SMOOTHING) {
                 strain_smoothing_node["nodal_smoothing_cell"] = element_smoothing_cell_node;
+            } else if (integration_scheme == PatchTestIntegrationScheme::NODAL_STRAIN_SMOOTHING_FORCE_TWO_PASS) {
+                strain_smoothing_node["nodal_smoothing_cell"] = element_smoothing_cell_node;
+                strain_smoothing_node["force_two_pass_method"] = true;
+            } else {
+                throw std::runtime_error("Invalid integration scheme");
             }
             m_yaml_data["procedures"][0]["explicit_dynamics_procedure"]["geometry"]["parts"][0]["part"]["formulation"]["integration_scheme"]["strain_smoothing"] = strain_smoothing_node;
             // Remove the gauss_quadrature node


### PR DESCRIPTION
Construct strain smoothing cell data so a one-pass method can also be used.

- One pass directly stores shape function derivatives. The displacement gradient is calculated from the coefficients and force coefficients are directly calculated. This performs better with nodal integration domains.
- Two pass method first stores "FE" shape function derivatives. The physical displacement is calculated before calculating force. The displacment gradient is calculated from the physical displacements and FE shape function derivatives. The force is calculated as "force_local" and then scattered to be "force_coefficients" by passing the local force through the shape functions. This performs better for element integration cells.