### PR TITLE
element outputs and volume calc

### DIFF
--- a/include/ComputeElementVolumeFunctor.h
+++ b/include/ComputeElementVolumeFunctor.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <Eigen/Dense>
+#include <array>
+#include <chrono>
+#include <memory>
+
+#include "ElementNodeProcessor.h"
+#include "Field.h"
+#include "FieldData.h"
+#include "LogUtils.h"
+#include "MeshData.h"
+
+namespace aperi {
+
+/**
+ * @brief Functor for computing the volume of an element using standard quadrature.
+ * @tparam NumNodes The max number of nodes in the element.
+ * @tparam FunctionsFunctor The functor for computing the shape functions.
+ * @tparam IntegrationFunctor The functor for computing the integration points and weights.
+ * @tparam StressFunctor The functor for computing the stress.
+ *
+ * @param mesh_data The mesh data.
+ * @param functions_functor The functor for computing the shape functions.
+ * @param integration_functor The functor for computing the integration points and weights.
+ *
+ * This functor computes the volume of an element using standard quadrature. The volume is computed by looping over all gauss points and integrating the volume.
+ *
+ */
+template <size_t NumNodes, typename FunctionsFunctor, typename IntegrationFunctor, typename StressFunctor>
+struct ComputeElementVolumeFunctor {
+    ComputeElementVolumeFunctor(const std::shared_ptr<aperi::MeshData> &mesh_data,
+                                const FunctionsFunctor &functions_functor,
+                                const IntegrationFunctor &integration_functor)
+        : m_functions_functor(functions_functor),
+          m_integration_functor(integration_functor) {
+        // Get the field data
+        m_coordinates_field = aperi::Field<double>(mesh_data, FieldQueryData<double>{mesh_data->GetCoordinatesFieldName(), FieldQueryState::None});
+        m_element_volume_field = aperi::Field<double>(mesh_data, FieldQueryData<double>{"volume", FieldQueryState::None, FieldDataTopologyRank::ELEMENT});
+    }
+
+    /**
+     * @brief Functor for computing the internal force of an element.
+     * @param elem_index The element index.
+     * @param nodes The nodes of the element.
+     * @param actual_num_nodes The actual number of nodes in the element.
+     */
+    KOKKOS_FUNCTION void operator()(const aperi::Index &elem_index, const Kokkos::Array<aperi::Index, NumNodes> &nodes, size_t actual_num_nodes) const {
+        // Set up the field data to gather
+        Eigen::Matrix<double, NumNodes, 3> node_coordinates = Eigen::Matrix<double, NumNodes, 3>::Zero();
+
+        // Gather the field data for each node
+        for (size_t i = 0; i < actual_num_nodes; ++i) {
+            node_coordinates.row(i).noalias() = m_coordinates_field.GetEigenMatrix<1, 3>(nodes[i]);
+        }
+        // Apply the function to compute the element volume
+        double element_volume = 0.0;
+
+        // Loop over all gauss points and integrate the volume
+        for (int gauss_id = 0; gauss_id < m_integration_functor.NumGaussPoints(); ++gauss_id) {
+            // Compute the B matrix and integration weight for a given gauss point
+            const Kokkos::pair<Eigen::Matrix<double, NumNodes, 3>, double> b_matrix_and_weight = m_integration_functor.ComputeBMatrixAndWeight(node_coordinates, m_functions_functor, gauss_id);
+
+            // Compute the volume of the element
+            element_volume += b_matrix_and_weight.second;
+        }
+
+        // Store the computed volume to the field
+        m_element_volume_field.data(elem_index)[0] = element_volume;
+    }
+
+   private:
+    aperi::Field<double> m_coordinates_field;             // The field for the node coordinates
+    mutable aperi::Field<double> m_element_volume_field;  // The field for the element volume
+
+    const FunctionsFunctor &m_functions_functor;      // Functor for computing the shape function values and derivatives
+    const IntegrationFunctor &m_integration_functor;  // Functor for computing the B matrix and integration weight
+};
+
+}  // namespace aperi

--- a/include/ComputeInternalForceFunctors.h
+++ b/include/ComputeInternalForceFunctors.h
@@ -8,66 +8,6 @@
 
 namespace aperi {
 
-// Functor for computing the internal force of an element with NumNodes nodes.
-// IntegrationFunctor is a functor that computes the B matrix and integration weight for a given gauss point.
-// StressFunctor is a functor that computes the stress of the material.
-template <size_t NumNodes, typename FunctionsFunctor, typename IntegrationFunctor, typename StressFunctor>
-struct ComputeInternalForceFromIntegrationPointFunctor {
-    ComputeInternalForceFromIntegrationPointFunctor(FunctionsFunctor &functions_functor, IntegrationFunctor &integration_functor, StressFunctor &stress_functor)
-        : m_functions_functor(functions_functor), m_integration_functor(integration_functor), m_stress_functor(stress_functor) {}
-
-    KOKKOS_INLINE_FUNCTION void operator()(const Kokkos::Array<Eigen::Matrix<double, NumNodes, 3>, 2> &gathered_node_data, Eigen::Matrix<double, NumNodes, 3> &force, size_t actual_num_neighbors, const double *state_old = nullptr, double *state_new = nullptr, size_t state_bucket_offset = 1) const {
-        const Eigen::Matrix<double, NumNodes, 3> &node_coordinates = gathered_node_data[0];
-        const Eigen::Matrix<double, NumNodes, 3> &node_displacements = gathered_node_data[1];
-
-        force.fill(0.0);
-
-        // Loop over all gauss points
-        for (int gauss_id = 0; gauss_id < m_integration_functor.NumGaussPoints(); ++gauss_id) {
-            // Compute the B matrix and integration weight for a given gauss point
-            const Kokkos::pair<Eigen::Matrix<double, NumNodes, 3>, double> b_matrix_and_weight = m_integration_functor.ComputeBMatrixAndWeight(node_coordinates, m_functions_functor, gauss_id);
-
-            // Compute displacement gradient
-            const Eigen::Matrix3d displacement_gradient = node_displacements.transpose() * b_matrix_and_weight.first;
-
-            // Create a map around the state_old and state_new pointers
-            Eigen::InnerStride<Eigen::Dynamic> state_stride(state_bucket_offset);
-            auto state_old_map = Eigen::Map<const Eigen::VectorXd, 0, Eigen::InnerStride<Eigen::Dynamic>>(state_old, m_stress_functor.NumberOfStateVariables(), state_stride);
-            auto state_new_map = Eigen::Map<Eigen::VectorXd, 0, Eigen::InnerStride<Eigen::Dynamic>>(state_new, m_stress_functor.NumberOfStateVariables(), state_stride);
-
-            // Compute the 1st pk stress and internal force of the element.
-            Eigen::Matrix<double, 3, 3> pk1_stress;
-            Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic> stride(3, 1);
-            auto pk1_stress_map = Eigen::Map<Eigen::Matrix<double, 3, 3>, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>>(pk1_stress.data(), stride);
-            auto displacement_gradient_map = Eigen::Map<const Eigen::Matrix<double, 3, 3>, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>>(displacement_gradient.data(), stride);
-            double timestep = 1.0;  // TODO(jake): This should be passed in
-            m_stress_functor.GetStress(&displacement_gradient_map, nullptr, &state_old_map, &state_new_map, timestep, pk1_stress_map);
-
-            // Compute the internal force
-            for (size_t i = 0; i < actual_num_neighbors; ++i) {
-                force.row(i).noalias() -= b_matrix_and_weight.first.row(i) * pk1_stress.transpose() * b_matrix_and_weight.second;
-            }
-        }
-    }
-
-    KOKKOS_INLINE_FUNCTION void ComputeElementVolume(const Eigen::Matrix<double, NumNodes, 3> &node_coordinates, double &volume) const {
-        volume = 0.0;
-
-        // Loop over all gauss points
-        for (int gauss_id = 0; gauss_id < m_integration_functor.NumGaussPoints(); ++gauss_id) {
-            // Compute the B matrix and integration weight for a given gauss point
-            const Kokkos::pair<Eigen::Matrix<double, NumNodes, 3>, double> b_matrix_and_weight = m_integration_functor.ComputeBMatrixAndWeight(node_coordinates, m_functions_functor, gauss_id);
-
-            // Compute the volume of the element
-            volume += b_matrix_and_weight.second;
-        }
-    }
-
-    FunctionsFunctor &m_functions_functor;      ///< Functor for computing the shape function values and derivatives
-    IntegrationFunctor &m_integration_functor;  ///< Functor for computing the B matrix and integration weight
-    StressFunctor &m_stress_functor;            ///< Functor for computing the stress of the material
-};
-
 template <size_t MaxNumNodes, typename StressFunctor>
 struct ComputeInternalForceFromSmoothingCellFunctor {
     ComputeInternalForceFromSmoothingCellFunctor(StressFunctor &stress_functor)

--- a/include/ElementHexahedron8.h
+++ b/include/ElementHexahedron8.h
@@ -168,6 +168,7 @@ class ElementHexahedron8 : public ElementBase {
         m_compute_force->SetTimeIncrement(time_increment);
         // Loop over all elements and compute the internal force
         m_element_node_processor->for_each_element_and_nodes(*m_compute_force);
+        m_compute_force->MarkFieldsModifiedOnDevice();
     }
 
    private:

--- a/include/ElementHexahedron8.h
+++ b/include/ElementHexahedron8.h
@@ -9,6 +9,7 @@
 #include "ComputeElementVolumeFunctor.h"
 #include "ComputeInternalForceFunctors.h"
 #include "ElementBase.h"
+#include "Field.h"
 #include "FieldData.h"
 #include "InternalForceProcessor.h"
 #include "Kokkos_Core.hpp"
@@ -148,8 +149,12 @@ class ElementHexahedron8 : public ElementBase {
         // Functor for computing the element volume
         auto compute_volume_functor = aperi::ComputeElementVolumeFunctor<HEX8_NUM_NODES, ShapeFunctionsFunctorHex8, Quadrature<8, HEX8_NUM_NODES>, Material::StressFunctor>(m_mesh_data, *m_shape_functions_functor, *m_integration_functor);
 
-        // Loop over all elements and compute the internal force
+        // Loop over all elements and compute the volume
         m_element_node_processor->for_each_element_and_nodes(compute_volume_functor);
+
+        auto element_volume_field = aperi::Field<double>(m_mesh_data, FieldQueryData<double>{"volume", FieldQueryState::None, FieldDataTopologyRank::ELEMENT});
+        element_volume_field.MarkModifiedOnDevice();
+        element_volume_field.SyncDeviceToHost();
     }
 
     /**

--- a/include/ElementReproducingKernel.h
+++ b/include/ElementReproducingKernel.h
@@ -62,7 +62,7 @@ class ElementReproducingKernel : public ElementBase {
         if (m_material) {
             has_state = m_material->HasState();
         }
-        m_element_processor = std::make_shared<ElementForceProcessor<1, true>>(m_field_query_data_gather, field_query_data_scatter, m_mesh_data, m_part_names, has_state);
+        m_element_processor = std::make_shared<ElementForceProcessor<1>>(m_field_query_data_gather, field_query_data_scatter, m_mesh_data, m_part_names, has_state);
     }
 
     void FindNeighbors() {
@@ -132,7 +132,7 @@ class ElementReproducingKernel : public ElementBase {
     const std::vector<std::string> m_part_names;
     std::shared_ptr<aperi::MeshData> m_mesh_data;
     double m_kernel_radius_scale_factor;
-    std::shared_ptr<aperi::ElementForceProcessor<1, true>> m_element_processor;
+    std::shared_ptr<aperi::ElementForceProcessor<1>> m_element_processor;
     std::shared_ptr<aperi::SmoothedCellData> m_smoothed_cell_data;
     bool m_use_one_pass_method;
 };

--- a/include/ElementSmoothedTetrahedron4.h
+++ b/include/ElementSmoothedTetrahedron4.h
@@ -68,27 +68,6 @@ class ElementSmoothedTetrahedron4 : public ElementBase {
     void ComputeSmoothedQuadrature() {
         assert(m_element_processor != nullptr);
         // Create the integration functor
-        auto integration_functor = CreateIntegrationFunctor();
-
-        // Build the smoothed cell data
-        aperi::StrainSmoothingProcessor strain_smoothing_processor(m_element_processor->GetMeshData(), this->m_element_processor->GetSets());
-        strain_smoothing_processor.for_each_neighbor_compute_derivatives<TET4_NUM_NODES>(integration_functor);
-        strain_smoothing_processor.ComputeCellVolumeFromElementVolume();
-        m_smoothed_cell_data = strain_smoothing_processor.BuildSmoothedCellData(TET4_NUM_NODES);
-
-        // Add the strain smoothing timer manager to the timer manager
-        m_timer_manager->AddChild(strain_smoothing_processor.GetTimerManager());
-
-        // Destroy the integration functor
-        Kokkos::parallel_for(
-            "DestroySmoothedTetrahedron4Functors", 1, KOKKOS_LAMBDA(const int &) {
-                integration_functor->~SmoothedQuadratureTet4();
-            });
-    }
-
-    // Create and destroy functors. Must be public to run on device.
-    SmoothedQuadratureTet4 *CreateIntegrationFunctor() {
-        // Functor for smooth quadrature
         size_t integration_functor_size = sizeof(SmoothedQuadratureTet4);
         auto integration_functor = (SmoothedQuadratureTet4 *)Kokkos::kokkos_malloc(integration_functor_size);
         assert(integration_functor != nullptr);
@@ -99,7 +78,22 @@ class ElementSmoothedTetrahedron4 : public ElementBase {
                 new ((SmoothedQuadratureTet4 *)integration_functor) SmoothedQuadratureTet4();
             });
 
-        return integration_functor;
+        // Build the smoothed cell data
+        aperi::StrainSmoothingProcessor strain_smoothing_processor(m_element_processor->GetMeshData(), this->m_element_processor->GetSets());
+        strain_smoothing_processor.for_each_neighbor_compute_derivatives<TET4_NUM_NODES>(integration_functor);
+        strain_smoothing_processor.ComputeCellVolumeFromElementVolume();
+        m_smoothed_cell_data = strain_smoothing_processor.BuildSmoothedCellData(TET4_NUM_NODES, true);
+
+        // Add the strain smoothing timer manager to the timer manager
+        m_timer_manager->AddChild(strain_smoothing_processor.GetTimerManager());
+
+        // Destroy the integration functor
+        Kokkos::parallel_for(
+            "DestroySmoothedTetrahedron4Functors", 1, KOKKOS_LAMBDA(const int &) {
+                integration_functor->~SmoothedQuadratureTet4();
+            });
+
+        Kokkos::kokkos_free(integration_functor);
     }
 
     /**
@@ -120,10 +114,14 @@ class ElementSmoothedTetrahedron4 : public ElementBase {
         assert(m_element_processor != nullptr);
 
         // Create the compute force functor
-        ComputeInternalForceFromSmoothingCellFunctor<TET4_NUM_NODES, Material::StressFunctor> compute_force_functor(*this->m_material->GetStressFunctor());
+        // ComputeInternalForceFromSmoothingCellFunctor<TET4_NUM_NODES, Material::StressFunctor> compute_force_functor(*this->m_material->GetStressFunctor());
+        // Create the compute stress functor
+        ComputeStressOnSmoothingCellFunctor<Material::StressFunctor> compute_stress_functor(*this->m_material->GetStressFunctor());
 
         // Loop over all elements and compute the internal force
-        m_element_processor->for_each_element_gather_scatter_nodal_data<TET4_NUM_NODES>(compute_force_functor);
+        // m_element_processor->for_each_element_gather_scatter_nodal_data<TET4_NUM_NODES>(compute_force_functor);
+        // Loop over all elements and compute the internal force
+        m_element_processor->for_each_cell_gather_scatter_nodal_data(*m_smoothed_cell_data, compute_stress_functor);
     }
 
    private:

--- a/include/ElementSmoothedTetrahedron4.h
+++ b/include/ElementSmoothedTetrahedron4.h
@@ -53,7 +53,7 @@ class ElementSmoothedTetrahedron4 : public ElementBase {
         if (m_material) {
             has_state = m_material->HasState();
         }
-        m_element_processor = std::make_shared<ElementForceProcessor<1, true>>(m_field_query_data_gather, field_query_data_scatter, m_mesh_data, m_part_names, has_state);
+        m_element_processor = std::make_shared<ElementForceProcessor<1>>(m_field_query_data_gather, field_query_data_scatter, m_mesh_data, m_part_names, has_state);
     }
 
     void FindNeighbors() {
@@ -130,7 +130,7 @@ class ElementSmoothedTetrahedron4 : public ElementBase {
     const std::vector<FieldQueryData<double>> m_field_query_data_gather;
     const std::vector<std::string> m_part_names;
     std::shared_ptr<aperi::MeshData> m_mesh_data;
-    std::shared_ptr<aperi::ElementForceProcessor<1, true>> m_element_processor;
+    std::shared_ptr<aperi::ElementForceProcessor<1>> m_element_processor;
     std::shared_ptr<aperi::SmoothedCellData> m_smoothed_cell_data;
 };
 

--- a/include/ElementTetrahedron4.h
+++ b/include/ElementTetrahedron4.h
@@ -9,7 +9,6 @@
 #include "ComputeElementVolumeFunctor.h"
 #include "ComputeInternalForceFunctors.h"
 #include "ElementBase.h"
-#include "ElementForceProcessor.h"
 #include "FieldData.h"
 #include "InternalForceProcessor.h"
 #include "Kokkos_Core.hpp"

--- a/include/ElementTetrahedron4.h
+++ b/include/ElementTetrahedron4.h
@@ -9,6 +9,7 @@
 #include "ComputeElementVolumeFunctor.h"
 #include "ComputeInternalForceFunctors.h"
 #include "ElementBase.h"
+#include "Field.h"
 #include "FieldData.h"
 #include "InternalForceProcessor.h"
 #include "Kokkos_Core.hpp"
@@ -138,8 +139,12 @@ class ElementTetrahedron4 : public ElementBase {
         // Functor for computing the element volume
         auto compute_volume_functor = aperi::ComputeElementVolumeFunctor<TET4_NUM_NODES, ShapeFunctionsFunctorTet4, Quadrature<1, TET4_NUM_NODES>, Material::StressFunctor>(m_mesh_data, *m_shape_functions_functor, *m_integration_functor);
 
-        // Loop over all elements and compute the internal force
+        // Loop over all elements and compute the volume
         m_element_node_processor->for_each_element_and_nodes(compute_volume_functor);
+
+        auto element_volume_field = aperi::Field<double>(m_mesh_data, FieldQueryData<double>{"volume", FieldQueryState::None, FieldDataTopologyRank::ELEMENT});
+        element_volume_field.MarkModifiedOnDevice();
+        element_volume_field.SyncDeviceToHost();
     }
 
     /**

--- a/include/ElementTetrahedron4.h
+++ b/include/ElementTetrahedron4.h
@@ -158,6 +158,7 @@ class ElementTetrahedron4 : public ElementBase {
         m_compute_force->SetTimeIncrement(time_increment);
         // Loop over all elements and compute the internal force
         m_element_node_processor->for_each_element_and_nodes(*m_compute_force);
+        m_compute_force->MarkFieldsModifiedOnDevice();
     }
 
    private:

--- a/include/Field.h
+++ b/include/Field.h
@@ -339,4 +339,13 @@ class Field {
     stk::mesh::NgpField<T> m_ngp_field;            // The ngp field object.
 };
 
+// Get a field if it exists
+template <typename T>
+std::shared_ptr<aperi::Field<T>> GetField(const std::shared_ptr<aperi::MeshData> &mesh_data, const aperi::FieldQueryData<T> &field_query_data) {
+    if (mesh_data == nullptr || !StkFieldExists(field_query_data, mesh_data->GetMetaData())) {
+        return nullptr;
+    }
+    return std::make_shared<aperi::Field<T>>(mesh_data, field_query_data);
+}
+
 }  // namespace aperi

--- a/include/InternalForceProcessor.h
+++ b/include/InternalForceProcessor.h
@@ -81,6 +81,16 @@ struct ComputeForce {
         }
     }
 
+    void MarkFieldsModifiedOnDevice() {
+        // Mark the fields as modified
+        m_force_field.MarkModifiedOnDevice();
+        m_displacement_gradient_np1_field.MarkModifiedOnDevice();
+        m_pk1_stress_field.MarkModifiedOnDevice();
+        if (m_has_state) {
+            m_state_np1_field.MarkModifiedOnDevice();
+        }
+    }
+
     /**
      * @brief Compute the velocity gradient.
      * @param elem_index The element index.

--- a/include/NeighborSearchProcessor.h
+++ b/include/NeighborSearchProcessor.h
@@ -461,6 +461,8 @@ class NeighborSearchProcessor {
             });
         m_ngp_node_num_neighbors_field->clear_sync_state();
         m_ngp_node_num_neighbors_field->modify_on_device();
+        m_ngp_node_neighbors_field->clear_sync_state();
+        m_ngp_node_neighbors_field->modify_on_device();
         if (set_first_function_value_to_one) {
             m_ngp_node_function_values_field->clear_sync_state();
             m_ngp_node_function_values_field->modify_on_device();

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -126,7 +126,9 @@ void ExplicitSolver::WriteOutput(double time) {
         UpdateFieldsFromGeneralizedFields();
     }
     // Write the field results
-    m_node_processor_output->SyncAllFieldsDeviceToHost();
+    for (auto &field : m_temporal_varying_output_fields) {
+        field.SyncDeviceToHost();
+    }
     m_io_mesh->WriteFieldResults(time);
 }
 

--- a/test/regression_tests/beam/fem/compare.exodiff
+++ b/test/regression_tests/beam/fem/compare.exodiff
@@ -3,14 +3,14 @@
 #             EXODIFF	(Version: 3.33) Modified: 2024-03-13
 #             Authors:  Richard Drake, rrdrake@sandia.gov           
 #                       Greg Sjaardema, gdsjaar@sandia.gov          
-#             Run on    2024/11/08   06:44:49 MST
+#             Run on    2025/01/16   01:28:34 UTC
 #  *****************************************************************
 
-#  FILE 1: /Users/jake/projects/aperi-mech/test/regression_tests/beam/fem/output_file.exo
+#  FILE 1: /home/aperi-mech_docker/aperi-mech/test/regression_tests/beam/fem/gold_results.exo
 #   Title: IOSS Default Output Title
 #          Dim = 3, Nodes = 20, Elements = 24, Faces = 0, Edges = 0
 #          Element Blocks = 1, Face Blocks = 0, Edge Blocks = 0, Nodesets = 6, Sidesets = 0, Assemblies = 0
-#    Vars: Global = 0, Nodal = 23, Element = 1, Face = 0, Edge = 0, Nodeset = 0, Sideset = 0, Times = 2
+#    Vars: Global = 0, Nodal = 23, Element = 19, Face = 0, Edge = 0, Nodeset = 0, Sideset = 0, Times = 2
 
 
 # ==============================================================
@@ -28,29 +28,50 @@ TIME STEPS relative 1.e-6 floor 0.0     # min:               0 @ t1 max:        
 # No GLOBAL VARIABLES
 
 NODAL VARIABLES relative 1.e-6 floor 0.0
-	displacement_x         # min:               0 @ t1,n1	max:    0.0080128092 @ t2,n5
-	displacement_y         # min:               0 @ t1,n1	max:    0.0078077954 @ t2,n8
-	displacement_z         # min:               0 @ t1,n1	max:      0.10000015 @ t2,n1
-	acceleration_x         # min:               0 @ t1,n1	max:      0.04789349 @ t2,n2
-	acceleration_y         # min:               0 @ t1,n1	max:     0.058725989 @ t2,n3
-	acceleration_z         # min:               0 @ t1,n1	max:      0.11258908 @ t2,n9
-	active                 # min:               1 @ t1,n1	max:               1 @ t1,n1
-	essential_boundary_x   # min:               0 @ t1,n1	max:               1 @ t1,n3
-	essential_boundary_y   # min:               0 @ t1,n2	max:               1 @ t1,n1
-	essential_boundary_z   # min:               0 @ t1,n9	max:               1 @ t1,n1
-	force_x   # min:   3.4108329e-09 @ t1,n8	max:   1.5168059e-06 @ t2,n3
-	force_y   # min:   5.9837756e-11 @ t1,n6	max:   8.0767925e-07 @ t2,n9
-	force_z   # min:   2.2584247e-10 @ t1,n5	max:   8.6259279e-05 @ t2,n5
-	mass_x                 # min:   4.1666667e-06 @ t1,n4	max:   4.1666667e-05 @ t1,n9
-	mass_y                 # min:   4.1666667e-06 @ t1,n4	max:   4.1666667e-05 @ t1,n9
-	mass_z                 # min:   4.1666667e-06 @ t1,n4	max:   4.1666667e-05 @ t1,n9
-	mass_from_elements_x   # min:   4.1666667e-06 @ t1,n4	max:   4.1666667e-05 @ t1,n9
-	mass_from_elements_y   # min:   4.1666667e-06 @ t1,n4	max:   4.1666667e-05 @ t1,n9
-	mass_from_elements_z   # min:   4.1666667e-06 @ t1,n4	max:   4.1666667e-05 @ t1,n9
-	max_edge_length        # min:               1 @ t1,n4	max:       1.7320508 @ t1,n1
-	velocity_x             # min:               0 @ t1,n1	max:     0.016094592 @ t2,n20
-	velocity_y             # min:               0 @ t1,n1	max:     0.015490801 @ t2,n8
-	velocity_z             # min:               0 @ t1,n1	max:      0.18749998 @ t2,n1
+	displacement_x            # min:               0 @ t1,n1	max:    0.0080129729 @ t2,n1
+	displacement_y            # min:               0 @ t1,n1	max:     0.007807006 @ t2,n4
+	displacement_z            # min:               0 @ t1,n1	max:     0.099998845 @ t2,n17
+	acceleration_x            # min:               0 @ t1,n1	max:     0.048816966 @ t2,n18
+	acceleration_y            # min:               0 @ t1,n1	max:     0.058400633 @ t2,n19
+	acceleration_z            # min:               0 @ t1,n1	max:       0.1124044 @ t2,n13
+	active                    # min:               1 @ t1,n1	max:               1 @ t1,n1
+	essential_boundary_x      # min:               0 @ t1,n1	max:               1 @ t1,n3
+	essential_boundary_y      # min:               0 @ t1,n1	max:               1 @ t1,n2
+	essential_boundary_z      # min:               0 @ t1,n5	max:               1 @ t1,n1
+	force_x                   # min:               0 @ t1,n1	max:    1.523228e-06 @ t2,n19
+	force_y                   # min:               0 @ t1,n1	max:   8.1178584e-07 @ t2,n13
+	force_z                   # min:               0 @ t1,n1	max:   8.6253447e-05 @ t2,n1
+	mass_x                    # min:   4.1666667e-06 @ t1,n4	max:   4.1666667e-05 @ t1,n13
+	mass_y                    # min:   4.1666667e-06 @ t1,n4	max:   4.1666667e-05 @ t1,n13
+	mass_z                    # min:   4.1666667e-06 @ t1,n4	max:   4.1666667e-05 @ t1,n13
+	mass_from_elements_x      # min:   4.1666667e-06 @ t1,n4	max:   4.1666667e-05 @ t1,n13
+	mass_from_elements_y      # min:   4.1666667e-06 @ t1,n4	max:   4.1666667e-05 @ t1,n13
+	mass_from_elements_z      # min:   4.1666667e-06 @ t1,n4	max:   4.1666667e-05 @ t1,n13
+	max_edge_length           # min:               1 @ t1,n4	max:       1.7320508 @ t1,n1
+	velocity_x                # min:               0 @ t1,n1	max:     0.016096852 @ t2,n8
+	velocity_y                # min:               0 @ t1,n1	max:     0.015482691 @ t2,n4
+	velocity_z                # min:               0 @ t1,n1	max:      0.18737109 @ t2,n17
+
+ELEMENT VARIABLES relative 1.e-6 floor 0.0
+	displacement_gradient_1   # min:               0 @ t1,b1,e1	max:    0.0080129729 @ t2,b1,e1
+	displacement_gradient_2   # min:               0 @ t1,b1,e1	max:   6.5559592e-05 @ t2,b1,e5
+	displacement_gradient_3   # min:               0 @ t1,b1,e1	max:   0.00052140088 @ t2,b1,e23
+	displacement_gradient_4   # min:               0 @ t1,b1,e1	max:   0.00026720765 @ t2,b1,e24
+	displacement_gradient_5   # min:               0 @ t1,b1,e1	max:     0.007807006 @ t2,b1,e2
+	displacement_gradient_6   # min:               0 @ t1,b1,e1	max:    0.0004507995 @ t2,b1,e16
+	displacement_gradient_7   # min:               0 @ t1,b1,e1	max:   0.00069344583 @ t2,b1,e17
+	displacement_gradient_8   # min:               0 @ t1,b1,e1	max:   0.00033225825 @ t2,b1,e15
+	displacement_gradient_9   # min:               0 @ t1,b1,e1	max:     0.026526601 @ t2,b1,e2
+	pk1_stress_1              # min:               0 @ t1,b1,e1	max:   4.0452161e-06 @ t2,b1,e24
+	pk1_stress_2              # min:               0 @ t1,b1,e1	max:   9.1952159e-07 @ t2,b1,e24
+	pk1_stress_3              # min:               0 @ t1,b1,e1	max:   1.2863402e-06 @ t2,b1,e14
+	pk1_stress_4              # min:               0 @ t1,b1,e1	max:   9.2018493e-07 @ t2,b1,e24
+	pk1_stress_5              # min:               0 @ t1,b1,e1	max:   2.7807837e-06 @ t2,b1,e15
+	pk1_stress_6              # min:               0 @ t1,b1,e1	max:   1.2194283e-06 @ t2,b1,e22
+	pk1_stress_7              # min:               0 @ t1,b1,e1	max:   1.3271401e-06 @ t2,b1,e14
+	pk1_stress_8              # min:               0 @ t1,b1,e1	max:   1.2568646e-06 @ t2,b1,e22
+	pk1_stress_9              # min:               0 @ t1,b1,e1	max:    0.0002592905 @ t2,b1,e2
+	volume                    # min:      0.16666667 @ t1,b1,e1	max:      0.16666667 @ t1,b1,e1
 
 # No NODESET VARIABLES
 

--- a/test/regression_tests/beam/fem/gold_results.exo
+++ b/test/regression_tests/beam/fem/gold_results.exo
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8403a55c138d98e6f09b55a1f28793c62d6e3a0cceea668b10f0e9b98e2b0618
-size 21368
+oid sha256:cc4377b3d0c5f980bd38dc8a221b8c156a5232bcc5c51f75bf05eddb14b51fc8
+size 40720

--- a/test/regression_tests/beam/fem_plasticity/compare.exodiff
+++ b/test/regression_tests/beam/fem_plasticity/compare.exodiff
@@ -3,14 +3,14 @@
 #             EXODIFF	(Version: 3.33) Modified: 2024-03-13
 #             Authors:  Richard Drake, rrdrake@sandia.gov           
 #                       Greg Sjaardema, gdsjaar@sandia.gov          
-#             Run on    2024/11/17   20:46:53 MST
+#             Run on    2025/01/16   01:35:58 UTC
 #  *****************************************************************
 
-#  FILE 1: /Users/jake/projects/aperi-mech/test/regression_tests/beam/fem_plasticity/gold_results.exo
+#  FILE 1: /home/aperi-mech_docker/aperi-mech/test/regression_tests/beam/fem_plasticity/gold_results.exo
 #   Title: IOSS Default Output Title
 #          Dim = 3, Nodes = 20, Elements = 24, Faces = 0, Edges = 0
 #          Element Blocks = 1, Face Blocks = 0, Edge Blocks = 0, Nodesets = 6, Sidesets = 0, Assemblies = 0
-#    Vars: Global = 0, Nodal = 32, Element = 6, Face = 0, Edge = 0, Nodeset = 0, Sideset = 0, Times = 2
+#    Vars: Global = 0, Nodal = 23, Element = 24, Face = 0, Edge = 0, Nodeset = 0, Sideset = 0, Times = 2
 
 
 # ==============================================================
@@ -28,32 +28,51 @@ TIME STEPS relative 1.e-6 floor 0.0     # min:               0 @ t1 max:        
 # No GLOBAL VARIABLES
 
 NODAL VARIABLES relative 1.e-6 floor 0.0
-	DISPLACEMENT_X              # min:               0 @ t1,n1	max:      0.35139749 @ t2,n2
-	DISPLACEMENT_Y              # min:               0 @ t1,n1	max:      0.27529558 @ t2,n3
-	DISPLACEMENT_Z              # min:               0 @ t1,n1	max:        1.500044 @ t2,n1
-	ACCELERATION_X              # min:               0 @ t1,n1	max:       2.5068004 @ t2,n2
-	ACCELERATION_Y              # min:               0 @ t1,n1	max:       1.3525476 @ t2,n8
-	ACCELERATION_Z              # min:               0 @ t1,n1	max:        1.928875 @ t2,n12
-	ACTIVE                      # min:               1 @ t1,n1	max:               1 @ t1,n1
-	ESSENTIAL_BOUNDARY_X        # min:               0 @ t1,n1	max:               1 @ t1,n3
-	ESSENTIAL_BOUNDARY_Y        # min:               0 @ t1,n2	max:               1 @ t1,n1
-	ESSENTIAL_BOUNDARY_Z        # min:               0 @ t1,n9	max:               1 @ t1,n1
-	FORCE_X        # min:               0 @ t1,n1	max:   5.1746074e-05 @ t2,n3
-	FORCE_Y        # min:               0 @ t1,n1	max:   4.2691205e-05 @ t2,n19
-	FORCE_Z        # min:               0 @ t1,n1	max:   0.00047589752 @ t2,n1
-	MASS_X                      # min:   4.1666667e-06 @ t1,n4	max:   4.1666667e-05 @ t1,n9
-	MASS_Y                      # min:   4.1666667e-06 @ t1,n4	max:   4.1666667e-05 @ t1,n9
-	MASS_Z                      # min:   4.1666667e-06 @ t1,n4	max:   4.1666667e-05 @ t1,n9
-	MASS_FROM_ELEMENTS_X        # min:   4.1666667e-06 @ t1,n4	max:   4.1666667e-05 @ t1,n9
-	MASS_FROM_ELEMENTS_Y        # min:   4.1666667e-06 @ t1,n4	max:   4.1666667e-05 @ t1,n9
-	MASS_FROM_ELEMENTS_Z        # min:   4.1666667e-06 @ t1,n4	max:   4.1666667e-05 @ t1,n9
-	MAX_EDGE_LENGTH             # min:               1 @ t1,n4	max:       1.7320508 @ t1,n1
-	VELOCITY_X                  # min:               0 @ t1,n1	max:      0.63134461 @ t2,n2
-	VELOCITY_Y                  # min:               0 @ t1,n1	max:      0.61634031 @ t2,n3
-	VELOCITY_Z                  # min:               0 @ t1,n1	max:       2.8123891 @ t2,n1
+	DISPLACEMENT_X            # min:               0 @ t1,n5	max:      0.35139749 @ t2,n2
+	DISPLACEMENT_Y            # min:               0 @ t1,n5	max:      0.27529558 @ t2,n3
+	DISPLACEMENT_Z            # min:               0 @ t1,n5	max:        1.500044 @ t2,n1
+	ACCELERATION_X            # min:               0 @ t1,n5	max:       2.5068004 @ t2,n2
+	ACCELERATION_Y            # min:               0 @ t1,n5	max:       1.3525476 @ t2,n8
+	ACCELERATION_Z            # min:               0 @ t1,n5	max:        1.928875 @ t2,n12
+	ACTIVE                    # min:               1 @ t1,n5	max:               1 @ t1,n5
+	ESSENTIAL_BOUNDARY_X      # min:               0 @ t1,n5	max:               1 @ t1,n7
+	ESSENTIAL_BOUNDARY_Y      # min:               0 @ t1,n5	max:               1 @ t1,n6
+	ESSENTIAL_BOUNDARY_Z      # min:               0 @ t1,n11	max:               1 @ t1,n5
+	FORCE_X                   # min:               0 @ t1,n5	max:   5.1746074e-05 @ t2,n3
+	FORCE_Y                   # min:               0 @ t1,n5	max:   4.2691205e-05 @ t2,n19
+	FORCE_Z                   # min:               0 @ t1,n5	max:   0.00047589752 @ t2,n1
+	MASS_X                    # min:   4.1666667e-06 @ t1,n8	max:   4.1666667e-05 @ t1,n9
+	MASS_Y                    # min:   4.1666667e-06 @ t1,n8	max:   4.1666667e-05 @ t1,n9
+	MASS_Z                    # min:   4.1666667e-06 @ t1,n8	max:   4.1666667e-05 @ t1,n9
+	MASS_FROM_ELEMENTS_X      # min:   4.1666667e-06 @ t1,n8	max:   4.1666667e-05 @ t1,n9
+	MASS_FROM_ELEMENTS_Y      # min:   4.1666667e-06 @ t1,n8	max:   4.1666667e-05 @ t1,n9
+	MASS_FROM_ELEMENTS_Z      # min:   4.1666667e-06 @ t1,n8	max:   4.1666667e-05 @ t1,n9
+	MAX_EDGE_LENGTH           # min:               1 @ t1,n8	max:       1.7320508 @ t1,n5
+	VELOCITY_X                # min:               0 @ t1,n5	max:      0.63134461 @ t2,n2
+	VELOCITY_Y                # min:               0 @ t1,n5	max:      0.61634031 @ t2,n3
+	VELOCITY_Z                # min:               0 @ t1,n5	max:       2.8123891 @ t2,n1
 
-# ELEMENT VARIABLES relative 1.e-6 floor 0.0
-	# STATE                       # min:               0 @ t1,b1,e1	max:       3.5399549 @ t2,b1,e2
+ELEMENT VARIABLES relative 1.e-6 floor 0.0
+	DISPLACEMENT_GRADIENT_1   # min:               0 @ t1,b1,e19	max:      0.35139749 @ t2,b1,e6
+	DISPLACEMENT_GRADIENT_2   # min:               0 @ t1,b1,e19	max:     0.024510954 @ t2,b1,e5
+	DISPLACEMENT_GRADIENT_3   # min:               0 @ t1,b1,e19	max:      0.13437289 @ t2,b1,e11
+	DISPLACEMENT_GRADIENT_4   # min:               0 @ t1,b1,e19	max:     0.072518831 @ t2,b1,e6
+	DISPLACEMENT_GRADIENT_5   # min:               0 @ t1,b1,e19	max:      0.27529558 @ t2,b1,e2
+	DISPLACEMENT_GRADIENT_6   # min:               0 @ t1,b1,e19	max:      0.11404264 @ t2,b1,e10
+	DISPLACEMENT_GRADIENT_7   # min:               0 @ t1,b1,e19	max:      0.13301544 @ t2,b1,e9
+	DISPLACEMENT_GRADIENT_8   # min:               0 @ t1,b1,e19	max:     0.064659983 @ t2,b1,e12
+	DISPLACEMENT_GRADIENT_9   # min:               0 @ t1,b1,e19	max:      0.65719172 @ t2,b1,e2
+	PK1_STRESS_1              # min:               0 @ t1,b1,e19	max:   0.00015106218 @ t2,b1,e6
+	PK1_STRESS_2              # min:               0 @ t1,b1,e19	max:   3.5715027e-05 @ t2,b1,e1
+	PK1_STRESS_3              # min:               0 @ t1,b1,e19	max:   4.1531734e-05 @ t2,b1,e1
+	PK1_STRESS_4              # min:               0 @ t1,b1,e19	max:   3.5715027e-05 @ t2,b1,e1
+	PK1_STRESS_5              # min:               0 @ t1,b1,e19	max:   0.00026665497 @ t2,b1,e10
+	PK1_STRESS_6              # min:               0 @ t1,b1,e19	max:   6.1874881e-05 @ t2,b1,e10
+	PK1_STRESS_7              # min:               0 @ t1,b1,e19	max:   4.1531734e-05 @ t2,b1,e1
+	PK1_STRESS_8              # min:               0 @ t1,b1,e19	max:   6.1874881e-05 @ t2,b1,e10
+	PK1_STRESS_9              # min:               0 @ t1,b1,e19	max:    0.0014126326 @ t2,b1,e4
+	STATE                     # min:               0 @ t1,b1,e19	max:       3.5399549 @ t2,b1,e2
+	VOLUME                    # min:      0.16666667 @ t1,b1,e19	max:      0.16666667 @ t1,b1,e19
 
 # No NODESET VARIABLES
 

--- a/test/regression_tests/beam/fem_plasticity/gold_results.exo
+++ b/test/regression_tests/beam/fem_plasticity/gold_results.exo
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:66c577cccdca999c5f6d8396bf865a76d661270e50d0593e3b2e94841c65e119
-size 21368
+oid sha256:d9fa9e8bb3f8ab6bd74dff29e08ff683195ef6df8d37d7246f3f867cc5f98319
+size 41424


### PR DESCRIPTION
- Changed element volume calculation to use new for_each_element_and_nodes
- Got pk1_stress, displacement_gradient, and state output working when running on device
- Changed smoothed tet4 to use SmoothedCellData to see if I can drop one ComputeForce branch