### PR TITLE
Updates and optimizations

### DIFF
--- a/include/ComputeInternalForceGaussian.h
+++ b/include/ComputeInternalForceGaussian.h
@@ -72,7 +72,7 @@ struct ComputeInternalForceGaussian : public ComputeInternalForceBase<aperi::Mat
         const size_t num_state_variables = m_has_state ? m_stress_functor.NumberOfStateVariables() : 0;
 
         // Get the stride
-        const size_t stride = m_has_state ? m_state_np1_field.GetStride() : 0;
+        const size_t stride = m_has_state ? m_state_np1_field.GetStride(elem_index()) : 0;
 
         // Default Stride for a 3x3 matrix
         const Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic> mat3_stride(3, 1);

--- a/include/ComputeInternalForceSmoothedCell.h
+++ b/include/ComputeInternalForceSmoothedCell.h
@@ -52,9 +52,6 @@ class ComputeInternalForceSmoothedCell : public ComputeInternalForceBase<aperi::
         // If using f_bar, only use it if there are more subcells than cells
         bool use_f_bar = m_use_f_bar && num_subcells != num_cells;
 
-        // Get the stride
-        const size_t stride = m_has_state ? m_state_np1_field.GetStride() : 0;
-
         // Default stride for a 3x3 matrix
         const Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic> mat3_stride(3, 1);
 
@@ -177,6 +174,9 @@ class ComputeInternalForceSmoothedCell : public ComputeInternalForceBase<aperi::
 
                 // Get the number of state variables
                 const size_t num_state_variables = m_has_state ? m_stress_functor.NumberOfStateVariables() : 0;
+
+                // Get the stride
+                const size_t stride = m_has_state ? m_state_np1_field.GetStride(elem_index) : 0;
 
                 // Get the state maps
                 Eigen::InnerStride<Eigen::Dynamic> state_stride(stride);

--- a/include/Field.h
+++ b/include/Field.h
@@ -65,8 +65,8 @@ class Field {
      * @brief Get the stride of the field data.
      * @return The stride of the field data.
      */
-    KOKKOS_FUNCTION unsigned GetStride() const {
-        return m_ngp_field.get_component_stride();
+    KOKKOS_FUNCTION unsigned GetStride(const aperi::Index &index) const {
+        return m_ngp_field.get_component_stride(index());
     }
 
     /**
@@ -126,7 +126,7 @@ class Field {
      */
     template <int Rows = Eigen::Dynamic, int Cols = Eigen::Dynamic>
     KOKKOS_FUNCTION Eigen::Map<Eigen::Matrix<T, Rows, Cols>, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>> GetEigenMatrixMap(const aperi::Index &index, size_t num_rows = Rows, size_t num_cols = Cols) {
-        const unsigned component_stride = m_ngp_field.get_component_stride();
+        const unsigned component_stride = m_ngp_field.get_component_stride(index());
         Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic> stride(component_stride, component_stride * num_cols);
         return Eigen::Map<Eigen::Matrix<T, Rows, Cols>, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>>(&m_ngp_field(index(), 0), num_rows, num_cols, stride);
     }
@@ -140,7 +140,7 @@ class Field {
      */
     template <int Rows = Eigen::Dynamic, int Cols = Eigen::Dynamic>
     KOKKOS_FUNCTION Eigen::Map<const Eigen::Matrix<T, Rows, Cols>, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>> GetEigenMatrixMap(const aperi::Index &index, size_t num_rows = Rows, size_t num_cols = Cols) const {
-        const unsigned component_stride = m_ngp_field.get_component_stride();
+        const unsigned component_stride = m_ngp_field.get_component_stride(index());
         Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic> stride(component_stride, component_stride * num_cols);
         return Eigen::Map<const Eigen::Matrix<T, Rows, Cols>, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>>(&m_ngp_field(index(), 0), num_rows, num_cols, stride);
     }
@@ -154,7 +154,7 @@ class Field {
      */
     template <int Rows = Eigen::Dynamic, int Cols = Eigen::Dynamic>
     KOKKOS_FUNCTION Eigen::Map<const Eigen::Matrix<T, Rows, Cols>, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>> GetConstEigenMatrixMap(const aperi::Index &index, size_t num_rows = Rows, size_t num_cols = Cols) const {
-        const unsigned component_stride = m_ngp_field.get_component_stride();
+        const unsigned component_stride = m_ngp_field.get_component_stride(index());
         Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic> stride(component_stride, component_stride * num_cols);
         return Eigen::Map<const Eigen::Matrix<T, Rows, Cols>, 0, Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>>(&m_ngp_field(index(), 0), num_rows, num_cols, stride);
     }
@@ -167,7 +167,7 @@ class Field {
      */
     template <int Size = Eigen::Dynamic>
     KOKKOS_FUNCTION Eigen::Map<Eigen::Vector<T, Size>, 0, Eigen::InnerStride<Eigen::Dynamic>> GetEigenVectorMap(const aperi::Index &index, size_t size = Size) {
-        const unsigned component_stride = m_ngp_field.get_component_stride();
+        const unsigned component_stride = m_ngp_field.get_component_stride(index());
         Eigen::InnerStride<Eigen::Dynamic> stride(component_stride);
         return Eigen::Map<Eigen::Vector<T, Size>, 0, Eigen::InnerStride<Eigen::Dynamic>>(&m_ngp_field(index(), 0), size, stride);
     }
@@ -180,7 +180,7 @@ class Field {
      */
     template <int Size = Eigen::Dynamic>
     KOKKOS_FUNCTION Eigen::Map<const Eigen::Vector<T, Size>, 0, Eigen::InnerStride<Eigen::Dynamic>> GetEigenVectorMap(const aperi::Index &index, size_t size = Size) const {
-        const unsigned component_stride = m_ngp_field.get_component_stride();
+        const unsigned component_stride = m_ngp_field.get_component_stride(index());
         Eigen::InnerStride<Eigen::Dynamic> stride(component_stride);
         return Eigen::Map<const Eigen::Vector<T, Size>, 0, Eigen::InnerStride<Eigen::Dynamic>>(&m_ngp_field(index(), 0), size, stride);
     }
@@ -193,7 +193,7 @@ class Field {
      */
     template <int Size = Eigen::Dynamic>
     KOKKOS_FUNCTION Eigen::Map<const Eigen::Vector<T, Size>, 0, Eigen::InnerStride<Eigen::Dynamic>> GetConstEigenVectorMap(const aperi::Index &index, size_t size = Size) const {
-        const unsigned component_stride = m_ngp_field.get_component_stride();
+        const unsigned component_stride = m_ngp_field.get_component_stride(index());
         Eigen::InnerStride<Eigen::Dynamic> stride(component_stride);
         return Eigen::Map<const Eigen::Vector<T, Size>, 0, Eigen::InnerStride<Eigen::Dynamic>>(&m_ngp_field(index(), 0), size, stride);
     }

--- a/include/SmoothedCellDataProcessor.h
+++ b/include/SmoothedCellDataProcessor.h
@@ -709,8 +709,6 @@ class SmoothedCellDataProcessor {
             // Get the state field
             state = aperi::Field<double>(m_mesh_data, state_query);
         }
-        const size_t stride = state_field_exist_on_part ? state.GetStride() : 0;
-
         // Get the number of subcells
         size_t num_subcells = m_smoothed_cell_data->NumSubcells();
 
@@ -723,6 +721,8 @@ class SmoothedCellDataProcessor {
                 // Get the pk1_stress and displacement_gradient of the first element as Eigen maps
                 const auto first_element_pk1_stress = pk1.GetConstEigenVectorMap<num_tensor_components>(first_element);
                 const auto first_element_displacement_gradient = displacement_gradient.GetConstEigenVectorMap<num_tensor_components>(first_element);
+
+                const size_t stride = state_field_exist_on_part ? state.GetStride(first_element) : 0;
 
                 // Get the state field map if it exists
                 Eigen::InnerStride<Eigen::Dynamic> state_stride(stride);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,7 @@
 #include <mpi.h>
 
+#include <Trilinos_version.h>
+#include <stk_util/Version.hpp>
 #include <Kokkos_Core.hpp>
 #include <chrono>
 #include <ctime>
@@ -39,6 +41,8 @@ void PrintHeader() {
     PrintVersion();
     aperi::CoutP0() << "  Git Branch: " << GIT_BRANCH << std::endl;
     aperi::CoutP0() << "  Git Tag: " << GIT_TAG << std::endl;
+    aperi::CoutP0() << "  Trilinos Version: " << TRILINOS_VERSION_STRING << std::endl;
+    aperi::CoutP0() << "  STK Version: " << stk::version_string() << std::endl;
     aperi::CoutP0() << "  Build Date: " << BUILD_DATE << std::endl;
     aperi::CoutP0() << "  Build Time: " << BUILD_TIME << std::endl;
     if (std::string(PROTEGO_MECH) == "ON") {

--- a/test/unit_tests/FieldTest.cpp
+++ b/test/unit_tests/FieldTest.cpp
@@ -296,7 +296,7 @@ struct DataOperation {
         double *p_data_ptr = field.data(index);
         KOKKOS_ASSERT(p_data_ptr != nullptr);
 
-        unsigned stride = field.GetStride();
+        unsigned stride = field.GetStride(index);
 
         size_t ptr_index = 0;
         for (size_t i = 0; i < Rows; i++) {

--- a/test/unit_tests/FieldTestFixture.h
+++ b/test/unit_tests/FieldTestFixture.h
@@ -105,7 +105,7 @@ class FieldTestFixture : public ::testing::Test {
             KOKKOS_LAMBDA(const stk::mesh::FastMeshIndex &entity) {
                 KOKKOS_ASSERT(ngp_field.get_num_components_per_entity(entity) == NumRows * NumColumns);
                 T *values = &ngp_field(entity, 0);
-                const unsigned component_stride = ngp_field.get_component_stride();
+                const unsigned component_stride = ngp_field.get_component_stride(entity);
 
                 size_t component = 0;
                 // Loop over the rows and columns, row major
@@ -142,7 +142,7 @@ class FieldTestFixture : public ::testing::Test {
             KOKKOS_LAMBDA(const stk::mesh::FastMeshIndex &entity) {
                 KOKKOS_ASSERT(ngp_field.get_num_components_per_entity(entity) == NumRows * NumColumns);
                 double *values = &ngp_field(entity, 0);
-                const unsigned component_stride = ngp_field.get_component_stride();
+                const unsigned component_stride = ngp_field.get_component_stride(entity);
 
                 // Create an Eigen::Map to the values
                 Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic> stride(component_stride, NumColumns * component_stride);

--- a/test/unit_tests/NgpTest.cpp
+++ b/test/unit_tests/NgpTest.cpp
@@ -6,6 +6,7 @@
 #include <stk_mesh/base/Entity.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/GetEntities.hpp>
+#include <stk_mesh/base/GetNgpMesh.hpp>
 #include <stk_mesh/base/GetNgpField.hpp>
 #include <stk_mesh/base/MeshBuilder.hpp>
 #include <stk_mesh/base/MetaData.hpp>


### PR DESCRIPTION
- some updates necessary to use trilinos/develop, such as passing an index to NgpField::get_component_stride(..)

- add m_syncCount and m_bucketIds in ExplicitTimeIntegrator to facilitate using the version of stk::mesh::for_each_entity_run that takes bucket-ids instead of a selector for improved performance.

- added fences around some timers. it would be better to add the fences inside the timer (fence before the timer is started and before the timer is stopped). And probably use a flag or macro so that the fences are not used in a release build or when timers are not requested. The fences don't cause a huge slowdown but probably a little...

- add a print in main to display the version of trilinos and stk that are being used.