### PR TITLE
Fixes for material separation

### DIFF
--- a/include/IoInputSchema.h
+++ b/include/IoInputSchema.h
@@ -485,6 +485,10 @@ YAML::Node GetInputSchema() {
     element_smoothing_cell_schema.AddAllOf(subdomains_node);
     YAML::Node element_smoothing_cell_node = element_smoothing_cell_schema.GetInputSchema();
 
+    // Deactivate subcells smaller than node
+    aperi::InputSchema deactivate_subcells_smaller_than_schema("deactivate_subcells_smaller_than", "float", "deactivate subcells smaller than this size");
+    YAML::Node deactivate_subcells_smaller_than_node = deactivate_subcells_smaller_than_schema.GetInputSchema();
+
     // Strain smoothing node
     aperi::InputSchema strain_smoothing_schema("strain_smoothing", "map", "strain smoothing");
     strain_smoothing_schema.AddOneOf(nodal_smoothing_cell_node);
@@ -493,6 +497,7 @@ YAML::Node GetInputSchema() {
     strain_smoothing_schema.AddOptional(force_two_pass_method_node);
     strain_smoothing_schema.AddOptional(use_f_bar_node);
     strain_smoothing_schema.AddOptional(activate_center_node_node);
+    strain_smoothing_schema.AddOptional(deactivate_subcells_smaller_than_node);
     YAML::Node strain_smoothing_node = strain_smoothing_schema.GetInputSchema();
 
     // Integration scheme node

--- a/include/MeshLabeler.h
+++ b/include/MeshLabeler.h
@@ -19,7 +19,7 @@ class MeshLabeler {
     void LabelPart(const MeshLabelerParameters& mesh_labeler_parameters) {
         MeshLabelerProcessor mesh_labeler_processor(m_mesh_data, mesh_labeler_parameters.set, mesh_labeler_parameters.num_subcells, mesh_labeler_parameters.activate_center_node);
         if (mesh_labeler_parameters.smoothing_cell_type == SmoothingCellType::Nodal) {
-            mesh_labeler_processor.LabelForThexNodalIntegration();
+            mesh_labeler_processor.LabelForThexNodalIntegration(mesh_labeler_parameters.deactivate_small_subcells, mesh_labeler_parameters.deactivate_subcells_smaller_than);
         } else if (mesh_labeler_parameters.smoothing_cell_type == SmoothingCellType::Element) {
             mesh_labeler_processor.LabelForElementIntegration();
         } else {

--- a/include/MeshLabelerParameters.h
+++ b/include/MeshLabelerParameters.h
@@ -36,13 +36,19 @@ struct MeshLabelerParameters {
             if (part["formulation"]["integration_scheme"]["strain_smoothing"]["activate_center_node"]) {
                 activate_center_node = part["formulation"]["integration_scheme"]["strain_smoothing"]["activate_center_node"].as<bool>();
             }
+            if (part["formulation"]["integration_scheme"]["strain_smoothing"]["deactivate_subcells_smaller_than"]) {
+                deactivate_small_subcells = true;
+                deactivate_subcells_smaller_than = part["formulation"]["integration_scheme"]["strain_smoothing"]["deactivate_subcells_smaller_than"].as<double>();
+            }
         }
     }
 
-    SmoothingCellType smoothing_cell_type;  // The type of smoothing cell
-    size_t num_subcells;                    // The number of subcells
-    std::string set;                        // The set to process
-    bool activate_center_node;              // Whether to activate the center node
+    SmoothingCellType smoothing_cell_type;          // The type of smoothing cell
+    size_t num_subcells;                            // The number of subcells
+    std::string set;                                // The set to process
+    bool activate_center_node;                      // Whether to activate the center node
+    bool deactivate_small_subcells = false;         // Whether to deactivate subcells smaller than a certain size
+    double deactivate_subcells_smaller_than = 0.0;  // The size below which subcells are deactivated
 };
 
 }  // namespace aperi


### PR DESCRIPTION
- only remove small subcells when requested
- handle eval points that are only attached to small subcells. this got the gpu material separation test working.